### PR TITLE
README: fix overlays copying command

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ pi64 linux # cp -v arch/arm64/boot/dts/broadcom/bcm2710-rpi-cm3.dtb /boot/
 
 Then, copy across the device tree overlay blobs (these are now the responsibility of the kernel, not the boot firmware, package, so it is essential you add them):
 ```console
-pi64 linux # cp -rv arch/arm64/boot/dts/overlays /boot/
+pi64 linux # cp -rv arch/arm64/boot/dts/overlays/ /boot/
 ```
 
 Lastly, install the modules:


### PR DESCRIPTION
The original command fails because the path used is a symlink, and /boot
is FAT filesystem which doesn't support symlinks:

    cp -rv arch/arm64/boot/dts/overlays /boot/boo
    'arch/arm64/boot/dts/overlays' -> '/boot/boo'
    cp: cannot create symbolic link '/boot/boo': Operation not permitted

Appending a slash to the source path causes the symlink to be resolved
rather than used intact.